### PR TITLE
Fix server startup for new multiplayer features

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "start": "concurrently \"npm run start:client\" \"npm run start:server\"",
     "start:client": "react-scripts start",
-    "start:server": "ts-node-dev --respawn --transpile-only server/index.ts",
+    "start:server": "ts-node-dev --respawn --compiler-options '{\"module\":\"CommonJS\"}' server/index.ts",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import http from 'http';
 import { Server } from 'socket.io';
 import path from 'path';
-import { Country } from '../src/lib/country';
+import type { Country } from '../src/lib/country';
 import { polygonDistance } from '../src/util/distance';
 import { getColour } from '../src/util/colour';
 import { answerCountry } from '../src/util/answer';


### PR DESCRIPTION
## Summary
- ensure the Country type is imported only for typing
- adjust start:server script so ts-node-dev runs the server using CommonJS modules

## Testing
- `npm test --silent --runInBand`
- `npm run start:server`

------
https://chatgpt.com/codex/tasks/task_e_68604bbf4b40832f8117725e10a6cf68