### PR TITLE
Implement socket-based rooms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ThemeContext } from "./context/ThemeContext";
 import Fade from "./transitions/Fade";
 import { MobileOnlyView, TabletView, BrowserView } from "react-device-detect";
 import SnackAdUnit from "./components/SnackAdUnit";
+import socket from "./socket";
 
 function App() {
   // State
@@ -25,6 +26,10 @@ function App() {
   useEffect(() => {
     if (reSpin) setTimeout(() => setReSpin(false), 1);
   }, [reSpin]);
+
+  useEffect(() => {
+    socket.connect();
+  }, []);
 
   const dark = themeContext.theme.nightMode ? "dark" : "";
 

--- a/src/components/Guesser.tsx
+++ b/src/components/Guesser.tsx
@@ -9,6 +9,7 @@ import localeList from "../i18n/messages";
 import { FormattedMessage } from "react-intl";
 import { langNameMap } from "../i18n/locales";
 import { AltNames } from "../lib/alternateNames";
+import socket from "../socket";
 const countryData: Country[] = require("../../data/countries.geo.json").features;
 const alternateNames: AltNames = require("../data/alternate_names.json");
 
@@ -18,6 +19,7 @@ type Props = {
   win: boolean;
   setWin: React.Dispatch<React.SetStateAction<boolean>>;
   practiceMode: boolean;
+  roomCode: string;
 };
 
 export default function Guesser({
@@ -26,6 +28,7 @@ export default function Guesser({
   win,
   setWin,
   practiceMode,
+  roomCode,
 }: Props) {
   const [guessName, setGuessName] = useState("");
   const [error, setError] = useState("");
@@ -90,7 +93,7 @@ export default function Guesser({
         setWin(true);
       }
     } else if (guessCountry.properties.NAME === answerName) {
-      setWin(true);
+      // win state handled by server
     }
     return guessCountry;
   }
@@ -115,7 +118,14 @@ export default function Guesser({
     }
     if (guessCountry && answerCountry) {
       guessCountry["proximity"] = polygonDistance(guessCountry, answerCountry);
-      setGuesses([...guesses, guessCountry]);
+      if (practiceMode) {
+        setGuesses([...guesses, guessCountry]);
+      } else {
+        socket.emit("guess", {
+          roomCode,
+          country: guessCountry.properties.WB_A3,
+        });
+      }
       setGuessName("");
     }
   }

--- a/src/components/RoomModal.tsx
+++ b/src/components/RoomModal.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import Fade from "../transitions/Fade";
+
+interface Props {
+  show: boolean;
+  roomCode: string;
+  onCreate: () => void;
+  onJoin: (code: string) => void;
+  onClose: () => void;
+}
+
+export default function RoomModal({
+  show,
+  roomCode,
+  onCreate,
+  onJoin,
+  onClose,
+}: Props) {
+  const [code, setCode] = useState("");
+
+  function join() {
+    if (code.trim()) onJoin(code.trim());
+  }
+
+  function copy() {
+    navigator.clipboard.writeText(roomCode);
+  }
+
+  return (
+    <Fade
+      show={show}
+      background="border-4 border-sky-300 dark:border-slate-700 bg-sky-100 dark:bg-slate-900 drop-shadow-xl absolute z-10 w-full sm:w-fit inset-x-0 mx-auto py-6 px-6 rounded-md space-y-2"
+    >
+      {roomCode ? (
+        <div className="space-y-4 text-center">
+          <p className="dark:text-gray-200">Room Code: {roomCode}</p>
+          <div className="space-x-2">
+            <button
+              className="bg-blue-700 text-white rounded-md px-4 py-2"
+              onClick={copy}
+            >
+              Copy
+            </button>
+            <button
+              className="bg-blue-700 text-white rounded-md px-4 py-2"
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4 text-center">
+          <input
+            className="border rounded-md p-2 w-full text-gray-900"
+            placeholder="Room code"
+            value={code}
+            onChange={(e) => setCode(e.currentTarget.value)}
+          />
+          <div className="space-x-2">
+            <button
+              className="bg-blue-700 text-white rounded-md px-4 py-2"
+              onClick={join}
+            >
+              Join
+            </button>
+            <button
+              className="bg-blue-700 text-white rounded-md px-4 py-2"
+              onClick={onCreate}
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      )}
+    </Fade>
+  );
+}


### PR DESCRIPTION
## Summary
- add `RoomModal` for copying or entering room codes
- connect to socket on mount
- join/create rooms and sync guesses via socket events
- emit guesses through socket instead of using local state

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686055b426d0832f956ea2d60ece757c